### PR TITLE
action button created

### DIFF
--- a/lib/button/action_button.dart
+++ b/lib/button/action_button.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+
+import '../theme/theme.dart';
+
+enum ButtonType {
+  primary,
+  text,
+  icon,
+}
+
+class ActionButton extends StatelessWidget {
+  final ButtonType buttonType;
+  const ActionButton({super.key, required this.buttonType});
+
+  Widget getButtonType(ButtonType buttonType, ThemeData theme) {
+    if (buttonType == ButtonType.primary) {
+      return primaryButton(theme);
+    } else if (buttonType == ButtonType.text) {
+      return textButton(theme);
+    } else {
+      return iconButton(theme);
+    }
+  }
+
+  Icon iconButton(ThemeData theme) => Icon(
+        Icons.qr_code_scanner_sharp,
+        color: theme.colors.light,
+        size: theme.spacing.width.s48,
+      );
+
+  Text textButton(ThemeData theme) => Text(
+        'New Expense',
+        style: theme.textStyle.headingLargeBold.copyWith(
+          color: theme.colors.light,
+        ),
+      );
+
+  Row primaryButton(ThemeData theme) => Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.add,
+            color: theme.colors.light,
+            size: theme.spacing.width.s32,
+          ),
+          SizedBox(width: theme.sizing.width.s2),
+          Text(
+            'New Expense',
+            style: theme.textStyle.headingLargeBold.copyWith(
+              color: theme.colors.light,
+            ),
+          ),
+        ],
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return GestureDetector(
+      child: Container(
+        padding: EdgeInsets.all(theme.spacing.width.s16),
+        decoration: BoxDecoration(
+          boxShadow:
+              buttonType == ButtonType.icon ? [theme.elevation.e1] : null,
+          color: theme.colors.secondary,
+          borderRadius: buttonType == ButtonType.icon
+              ? BorderRadius.circular(
+                  theme.borderradius.full(theme.sizing.width.s20),
+                )
+              : BorderRadius.circular(
+                  theme.borderradius.normal,
+                ),
+        ),
+        child: getButtonType(
+          buttonType,
+          theme,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/theme/extensions/miny_colors.dart
+++ b/lib/theme/extensions/miny_colors.dart
@@ -12,6 +12,7 @@ class MinyColors extends ThemeExtension<MinyColors> {
   final Color contrastLight;
   final Color light;
   final Color dark;
+  final Color shadow;
 
   const MinyColors({
     this.primary = ColorTokens.primary,
@@ -24,6 +25,7 @@ class MinyColors extends ThemeExtension<MinyColors> {
     this.contrastLight = ColorTokens.contrastLight,
     this.light = ColorTokens.light,
     this.dark = ColorTokens.dark,
+    this.shadow = ColorTokens.shadow,
   });
 
   @override
@@ -38,6 +40,7 @@ class MinyColors extends ThemeExtension<MinyColors> {
     Color? contrastLight,
     Color? light,
     Color? dark,
+    Color? shadow,
   }) =>
       MinyColors(
         primary: primary ?? this.primary,
@@ -50,6 +53,7 @@ class MinyColors extends ThemeExtension<MinyColors> {
         contrastLight: contrastLight ?? this.contrastLight,
         light: light ?? this.light,
         dark: dark ?? this.dark,
+        shadow: shadow ?? this.shadow,
       );
 
   @override
@@ -67,6 +71,7 @@ class MinyColors extends ThemeExtension<MinyColors> {
       contrastLight: Color.lerp(contrastLight, other.contrastLight, t)!,
       light: Color.lerp(light, other.light, t)!,
       dark: Color.lerp(dark, other.dark, t)!,
+      shadow: Color.lerp(shadow, other.shadow, t)!,
     );
   }
 }

--- a/lib/theme/tokens/color_tokens.dart
+++ b/lib/theme/tokens/color_tokens.dart
@@ -12,4 +12,5 @@ class ColorTokens {
   static const Color contrastLight = Color(0xFFF4F4F4);
   static const Color dark = Color(0xFF000000);
   static const Color light = Color(0xFFFFFFFF);
+  static const Color shadow = Color(0xFFBFBFBF);
 }


### PR DESCRIPTION
### Release

1.0.0
https://blackminystudio.atlassian.net/browse/TPA-43

### Description
-created actionButton
-update shadow in colors


### Screenshots
![actionButton](https://github.com/user-attachments/assets/11e66704-d46a-4e59-9a7d-0428120c1ace)


### Tips
```bash
class HomeScreen extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    final theme = Theme.of(context);
    return Scaffold(
      backgroundColor: theme.colors.light,
      body: const Center(
        child: ActionButton(
          buttonType: ButtonType.text,
        ),
      ),
    );
  }
}
```

---

### IMPORTANT:

- (REQUIRED) Coverage Screenshots for the tests written
- (REQUIRED) UI Screenshots for the UI implementation written

### Author preparation checklist

- [ ] Current branch is rebased with latest 'main' branch
- [x] PR is targeting only one issue
- [x] Commit messages are descriptive, consistent, and follow the project's guidelines.
- [ ] Branch name matches with at least `<jira link reference>-<short change description>`
- [x] Primary reviewer is set as assignee to the PR
- [x] No unnecessary changes on `pubspec.lock`
- [x] All added TODOs have associated Github issue references
- [x] \*.iml and, pubsepc_overrides.yaml are not checkedin

### Primary reviewer checklist

- [ ] All items in the author checklist is checked or not applicable
- [x] All files including .lock and assets are reviewed
- [x] Reasonable UI flows/cases related to the change are manually tested
- [x] No commented-out code or unnecessary debug statements.
- [ ] No spelling or grammatical errors in code comments or documentation.
- [ ] No sensitive data (e.g., API keys, credentials) is hardcoded or exposed.
- [ ] The branch is up-to-date with the target branch (e.g., staging).

### Pre-merge checklist

- [ ] Two approvals received. (Changes affecting automatic PR verification, like new linter rules, formatting rules, Github workflow configurations)

---
